### PR TITLE
Add Georgia Power scraper

### DIFF
--- a/georgia_power_scraper.py
+++ b/georgia_power_scraper.py
@@ -1,0 +1,10 @@
+from kubra_scraper import KubraScraper
+
+
+class GeorgiaPowerScraper(KubraScraper):
+    owner = "codeforkyana"
+    repo = "power-outage-data"
+    filepath = "georgia-power/outages.json"
+
+    instance_id = "7b38c047-7950-444b-a25c-9b3e5ab986eb"
+    view_id = "67b44af5-3847-4ca3-9f4e-9190aac343d6"


### PR DESCRIPTION
This is an example of what's required to set up a new scraper.

If this repo is cloned,`lgeku_scraper.py` can be replaced with another location-specific scraper, like the one in this PR.

`instance_id` and `view_id` come from the site’s HTML: https://outagemap.georgiapower.com/external/default.html

`owner` and `repo` need to be set to the repo where the outage JSON should be written.

The only other thing to do is to add a GitHub token to the cloned repo's Actions so that it can write to the destination repo.

1) Create a personal access token using an account that has access to the destination repo: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
2) Add it to GitHub actions, giving it the name `GH_TOKEN`: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

The [action](https://github.com/codeforkyana/kubra-scraper/blob/master/.github/workflows/pythonapp.yml) should have been copied over and should be picked up and execute an Action every 15 minutes, scraping and saving the current outages.