### PR TITLE
Pepco example

### DIFF
--- a/pepco_scraper.py
+++ b/pepco_scraper.py
@@ -1,0 +1,10 @@
+from kubra_scraper import KubraScraper
+
+
+class PepcoScraper(KubraScraper):
+    owner = "codeforkyana"
+    repo = "power-outage-data"
+    filepath = "pepco/outages.json"
+
+    instance_id = "bac68083-1c42-44ee-bb3c-6d1c1c026f52"
+    view_id = "66f63a73-3b4a-4b2a-a833-f01668ef4986"

--- a/scrape_all.py
+++ b/scrape_all.py
@@ -25,6 +25,7 @@ def discover_scrapers(token):
                         issubclass(klass, DeltaScraper)
                         and klass.__module__ != "kubra_scraper"
                         and klass.__module__ != "base_scraper"
+                        and klass.__module__ != "lgeku_scraper"
                     ):
                         scrapers.append(klass(token))
                 except TypeError:


### PR DESCRIPTION
This is an example of what's required to set up a new scraper.

Read more about why this data can be useful and how it can be made available here:
https://codeforkentuckiana.org/2019-12-18-power-utility-data/

If this repo is cloned, `lgeku_scraper.py` can be replaced with another location-specific scraper, like the one in this PR.

`instance_id` and `view_id` come from the outage map's HTML: 
https://kubra.io/stormcenter/views/66f63a73-3b4a-4b2a-a833-f01668ef4986
which is iframed in:
https://www.pepco.com/Outages/CheckOutageStatus/Pages/ViewOutageMap.aspx

`owner` and `repo` need to be set to the repo where the outage JSON should be written.

The only other thing to do is to add a GitHub token to the cloned repo's Actions so that it can write to the destination repo.

1. Create a personal access token using an account that has access to the destination repo: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
2. Add it to GitHub actions, giving it the name GH_TOKEN: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

The [action](https://github.com/codeforkyana/kubra-scraper/blob/master/.github/workflows/pythonapp.yml) should have been copied over and should be picked up and execute an Action every 15 minutes, scraping and saving the current outages.